### PR TITLE
Use /sbin/openrc-run instead of /sbin/runscript

### DIFF
--- a/net-nntp/couchpotato/files/couchpotato.init
+++ b/net-nntp/couchpotato/files/couchpotato.init
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright 1999-2012 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $

--- a/net-nntp/headphones/files/headphones.init
+++ b/net-nntp/headphones/files/headphones.init
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright 1999-2012 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $

--- a/net-nntp/moviegrabber/files/moviegrabber.init
+++ b/net-nntp/moviegrabber/files/moviegrabber.init
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $

--- a/net-nntp/sabnzbd/files/sabnzbd.init
+++ b/net-nntp/sabnzbd/files/sabnzbd.init
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright 1999-2012 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $

--- a/net-nntp/sickbeard/files/sickbeard.init
+++ b/net-nntp/sickbeard/files/sickbeard.init
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright 1999-2012 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $

--- a/www-apps/maraschino/files/maraschino.init
+++ b/www-apps/maraschino/files/maraschino.init
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright 1999-2012 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $


### PR DESCRIPTION
Since the latest stable version of OpenRC in the Portage tree, 0.21.3, spits out warnings when running init scripts using `/sbin/runscript` instead of `/sbin/openrc-run`, this pull request modifies all init scripts to use `/sbin/openrc-run`.