### PR TITLE
Version bump: SABnzbd+ 1.1.0

### DIFF
--- a/net-nntp/sabnzbd/files/sabnzbd.conf
+++ b/net-nntp/sabnzbd/files/sabnzbd.conf
@@ -1,13 +1,14 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
+# $Id$
 
 # Config file for sabnzbd init script
 
-# Version of Python ("2.6", "2.7" or "2"; default should work for almost everyone)
+# Version of Python ("2.7" or "2"; default should work for almost everyone)
 python_bin="python2"
 
-# Location of config file. # Make sure the user specified below can read and write to this file.
+# Location of config file.
+# Make sure the user specified below can read and write to this file.
 # Only change this if you really know what you are doing!
 config_file="/etc/sabnzbd/sabnzbd.ini"
 

--- a/net-nntp/sabnzbd/files/sabnzbd.init
+++ b/net-nntp/sabnzbd/files/sabnzbd.init
@@ -1,7 +1,7 @@
 #!/sbin/openrc-run
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
+# $Id$
 
 depend() {
         need net

--- a/net-nntp/sabnzbd/files/sabnzbd.logrotate
+++ b/net-nntp/sabnzbd/files/sabnzbd.logrotate
@@ -1,6 +1,6 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
+# $Id$
 
 /var/log/sabnzbd/*.log{
 	missingok

--- a/net-nntp/sabnzbd/sabnzbd-1.1.0.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-1.1.0.ebuild
@@ -1,0 +1,83 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI="6"
+
+# Require python-2 with sqlite USE flag
+PYTHON_COMPAT=( python2_7 )
+PYTHON_REQ_USE="sqlite"
+
+inherit eutils python-single-r1 user
+
+MY_P="${P/sab/SAB}"
+
+DESCRIPTION="Free and easy binary newsreader"
+HOMEPAGE="http://www.sabnzbd.org/"
+SRC_URI="https://github.com/${PN}/${PN}/releases/download/${PV}/${MY_P}-src.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE=""
+
+RDEPEND="
+	app-arch/par2cmdline
+	app-arch/unrar
+	app-arch/unzip
+	dev-python/cheetah
+	dev-python/pyopenssl
+	dev-python/yenc
+	${PYTHON_DEPS}
+"
+
+DEPEND="${PYTHON_DEPS}"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+S="${WORKDIR}/${MY_P}"
+DHOMEDIR="/var/${PN}"
+
+pkg_setup() {
+	python-single-r1_pkg_setup
+
+	# Create sabnzbd group
+	enewgroup ${PN}
+	# Create sabnzbd user, put in sabnzbd group
+	enewuser ${PN} -1 -1 -1 ${PN}
+}
+
+src_install() {
+	dodoc {ABOUT,ISSUES,README}.txt scripts/{Sample-PostProc.sh,Sample-PostProc.cmd}
+
+	newconfd "${FILESDIR}/${PN}.conf" ${PN}
+	newinitd "${FILESDIR}/${PN}.init" ${PN}
+	keepdir /var/{${PN}/{admin,backup,cache,complete,download,dirscan},log/${PN}}
+	fowners -R ${PN}:${PN} /var/{${PN}/{,admin,backup,cache,complete,download,dirscan},log/${PN}}
+
+	# Default configuration file and directory
+
+	insinto /etc/${PN}
+	insopts -m0660 -o ${PN} -g ${PN}
+	doins "${FILESDIR}/${PN}.ini"
+
+	# Add themes & code into /usr/share
+	insinto /usr/share/${PN}
+	doins -r cherrypy email gntp icons interfaces locale po sabnzbd SABnzbd.py tools util
+
+	python_optimize "${D}usr/share/${PN}"
+}
+
+pkg_postinst() {
+	elog "SABnzbd has been installed with default directories in /var/${PN}"
+	elog
+	elog "New user/group ${PN}/${PN} has been created"
+	elog
+	elog "Config file is located in /etc/${PN}/${PN}.ini"
+	elog
+	elog "Please configure /etc/conf.d/${PN} before starting as daemon!"
+	elog
+	elog "Start with ${ROOT}etc/init.d/${PN} start"
+	elog "Visit http://<host ip>:8080 to configure SABnzbd"
+	elog "Default web username/password : sabnzbd/secret"
+	elog
+}


### PR DESCRIPTION
This pull request adds an ebuild for SABnzbd+ 1.1.0, which contains the following changes compared to the ebuild for version 1.0.3:
- move to EAPI 6,
- move from `python.eclass` to `python-single-r1`, as per [Gentoo docs](https://wiki.gentoo.org/wiki/Project:Python/Python.eclass_conversion),
- require at least Python 2.7, as per [upstream](https://github.com/sabnzbd/sabnzbd/releases/tag/1.1.0),
- change `DESCRIPTION` to one taken from SABnzbd+'s website, to make `repoman` happy,
- use GitHub instead of SourceForge in `SRC_URI`.
